### PR TITLE
Revert "lineage-sdk: Update the way OMS records details about overlays"

### DIFF
--- a/lineage/lib/main/java/org/lineageos/platform/internal/StyleInterfaceService.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/StyleInterfaceService.java
@@ -161,8 +161,7 @@ public class StyleInterfaceService extends LineageSystemService {
 
         try {
             PackageInfo pi = mPackageManager.getPackageInfo(pkgName, 0);
-            return pi != null && (pi.overlayFlags & PackageInfo.FLAG_OVERLAY_STATIC) == 0 &&
-                    isValidAccent(pkgName);
+            return pi != null && !pi.isStaticOverlay && isValidAccent(pkgName);
         } catch (PackageManager.NameNotFoundException e) {
             return false;
         }


### PR DESCRIPTION
This reverts commit 210184be49f2ad7d979af7c0bd5162d63c334414.

Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>